### PR TITLE
Allow PascalCase variables

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -12,6 +12,7 @@
     "rules": {
         "class-name": true,
         "comment-format": [true, "check-space"],
+        "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case"],
         "indent": [true, "spaces"],
         "one-line": [true, "check-open-brace", "check-whitespace"],
         "no-var-keyword": true,


### PR DESCRIPTION
Typically PascalCase is used to denote components, unlike camelCase and CONST_CASE. Since we mostly use this configuration with React projects, we should allow the use of PascalCase. This PR enables just that.