### PR TITLE
Enable multiline strings

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -44,8 +44,7 @@
         "no-submodule-imports": false,
         "no-http-string": false,
         "no-increment-decrement": false,
-        "no-string-literal": false,
-        "no-suspicious-comment": false
+        "no-string-literal": false
     },
     "rulesDirectory": []
 }

--- a/tslint.json
+++ b/tslint.json
@@ -44,7 +44,8 @@
         "no-submodule-imports": false,
         "no-http-string": false,
         "no-increment-decrement": false,
-        "no-string-literal": false
+        "no-string-literal": false,
+        "no-multiline-string": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
It's very common to use multiline strings for other languages embedded in JS or JSX; for example, with GraphQL or CSS. Sometimes you even need the newline characters included in your string template literal. There doesn't appear to be an explanation for why these are disabled by `tslint-microsoft-contrib`, so this PR re-enables them. It also re-enables suspicious comments, because, at least internally, any technical overhead needs to be in a Jira issue or written in big letters on a whiteboard.